### PR TITLE
Add `csc.rsp` to avoid warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,4 @@ VItalRouter.Benchmark/obj/*
 
 .DS_Store
 
+!VitalRouter.Unity/Assets/csc.rsp

--- a/VitalRouter.Unity/Assets/csc.rsp
+++ b/VitalRouter.Unity/Assets/csc.rsp
@@ -1,0 +1,1 @@
+-langVersion:preview -nullable


### PR DESCRIPTION
- Fixed a problem with readonly package fix warnings on Unity Editor.
    ```
    A meta data file (.meta) exists but its asset 'Packages/jp.hadashikick.vitalrouter/Runtime/csc.rsp' can't be found. When moving or deleting files outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.
    ```
    ```
    Couldn't delete Packages/jp.hadashikick.vitalrouter/Runtime/csc.rsp.meta because it's in an immutable folder.
    ```
- I have assumed `langVersion:preview` (C# 11), but if C# 10 is sufficient, downgrade to C# 10.