### PR TITLE
Refine fan-out APIs

### DIFF
--- a/VitalRouter.Unity/Assets/VitalRouter/Runtime/CommandOrdering.cs
+++ b/VitalRouter.Unity/Assets/VitalRouter/Runtime/CommandOrdering.cs
@@ -11,6 +11,20 @@ public enum CommandOrdering
     FirstInFirstOut,
 }
 
+public partial class Router
+{
+    public Router Filter(CommandOrdering ordering)
+    {
+        switch (ordering)
+        {
+            case CommandOrdering.FirstInFirstOut:
+                Filter(FirstInFirstOutOrdering.Instance);
+                break;
+        }
+        return this;
+    }
+}
+
 public class FirstInFirstOutOrdering : ICommandInterceptor, IDisposable
 {
     public static readonly FirstInFirstOutOrdering Instance = new();
@@ -37,13 +51,5 @@ public class FirstInFirstOutOrdering : ICommandInterceptor, IDisposable
     public void Dispose()
     {
         publishLock.Dispose();
-    }
-}
-
-public static class RouterCommandOrderingExtensions
-{
-    public static Router FirstInFirstOut(this Router router)
-    {
-        return router.Filter(FirstInFirstOutOrdering.Instance);
     }
 }

--- a/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/VContainerExtensions.cs
+++ b/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/VContainerExtensions.cs
@@ -65,6 +65,7 @@ public class RoutingBuilder
 {
     public InterceptorStackBuilder Filters { get; } = new();
     public bool Isolated { get; set; }
+    public CommandOrdering Ordering { get; set; }
 
     internal readonly List<MapRoutesInfo> MapRoutesInfos = new();
     internal readonly List<RoutingBuilder> Subsequents = new();
@@ -192,6 +193,13 @@ public static class VContainerExtensions
 
     static void RegisterVitalRouterInterceptors(this IContainerBuilder builder, RoutingBuilder routing)
     {
+        switch (routing.Ordering)
+        {
+            case CommandOrdering.FirstInFirstOut:
+                routing.Filters.Add<FirstInFirstOutOrdering>();
+                break;
+        }
+
         foreach (var interceptorType in routing.Filters.Types)
         {
             builder.Register(interceptorType, Lifetime.Singleton);


### PR DESCRIPTION
- The method `.FirstInFirstOut()` is very confusing as to whether it returns a reference or mutates.
  -> `.Filter(...) I decided to unify it with `. Add `.Filter(CommandOrdering.FirstInFirstOut)`.
  -> `.DI' is similar, but this one does not need exclusive control, so I changed it to options style. FirstInFirstOut`.
- In the case of fan-out, the lower level is FIFO and the upper level is Parallel. The upper-level interceptor should not fire and forget, but should be await.
