### PR TITLE
Downgrade language version to Unity default

### DIFF
--- a/src/VitalRouter.Unity/Assets/Sandbox/RoutingBehaviour.cs
+++ b/src/VitalRouter.Unity/Assets/Sandbox/RoutingBehaviour.cs
@@ -1,8 +1,8 @@
 using UnityEngine;
 using VitalRouter;
 
-namespace MyNamespace;
-
+namespace MyNamespace
+{
 
 [Routes]
 public partial class RoutingBehaviour : MonoBehaviour
@@ -17,3 +17,4 @@ public partial class RoutingBehaviour : MonoBehaviour
     }
 }
 
+}

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/ExpandBufferTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/ExpandBufferTest.cs
@@ -1,8 +1,8 @@
 using NUnit.Framework;
 using VitalRouter.Internal;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 [TestFixture]
 public class ExpandBufferTest
 {
@@ -24,4 +24,5 @@ public class ExpandBufferTest
         Assert.That(x[0], Is.EqualTo(111));
         Assert.That(x[1], Is.EqualTo(333));
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/FreeListTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/FreeListTest.cs
@@ -1,8 +1,8 @@
 using NUnit.Framework;
 using VitalRouter.Internal;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 [TestFixture]
 public class FreeListTest
 {
@@ -59,4 +59,5 @@ public class FreeListTest
         var span = freeList.AsSpan();
         Assert.That(span.Length, Is.EqualTo(0));
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/GeneratedRoutingTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/GeneratedRoutingTest.cs
@@ -5,8 +5,8 @@ using Cysharp.Threading.Tasks;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 [TestFixture]
 public class GeneratedRoutingTest
 {
@@ -379,4 +379,5 @@ partial class TaskPresenter
     {
         return default;
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/R3ExtensionsTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/R3ExtensionsTest.cs
@@ -8,8 +8,8 @@ using NUnit.Framework;
 using R3;
 using VitalRouter.R3;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 [TestFixture]
 public class R3ExtensionsTest
 {
@@ -183,3 +183,4 @@ public class R3ExtensionsTest
     }
 }
 #endif
+}

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/RouterTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/RouterTest.cs
@@ -4,8 +4,8 @@ using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 class TestSubscriber : ICommandSubscriber
 {
     public int Calls { get; private set; }
@@ -203,4 +203,5 @@ public class RouterTest
         await task2;
         Assert.That(subscriber1.Completed, Is.EqualTo(2));
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/TestFixtures.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/TestFixtures.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 class AInterceptor : ICommandInterceptor
 {
     public readonly Queue<ICommand> Receives = new();
@@ -121,4 +121,5 @@ class CommandD : ICommand
     {
         Value = value;
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/UniTaskAsyncLockTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/UniTaskAsyncLockTest.cs
@@ -3,8 +3,8 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using VitalRouter.Internal;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 [TestFixture]
 class UniTaskAsyncLockTest
 {
@@ -112,4 +112,5 @@ class UniTaskAsyncLockTest
         Assert.That(result1, Is.True);
         Assert.That(result2, Is.True);
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/UnsafeHelperTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/UnsafeHelperTest.cs
@@ -1,8 +1,9 @@
 using NUnit.Framework;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 [TestFixture]
 public class UnsafeHelperTest
 {
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/WhenAllTest.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/WhenAllTest.cs
@@ -5,8 +5,8 @@ using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using VitalRouter.Internal;
 
-namespace VitalRouter.Tests;
-
+namespace VitalRouter.Tests
+{
 [TestFixture]
 public class WhenAllTest
 {
@@ -34,3 +34,4 @@ public class WhenAllTest
     }
 }
 #endif
+}

--- a/src/VitalRouter.Unity/Assets/VitalRouter.Tests/csc.rsp
+++ b/src/VitalRouter.Unity/Assets/VitalRouter.Tests/csc.rsp
@@ -1,1 +1,1 @@
--langVersion:10 -nullable
+-nullable

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/AnonymousInterceptor.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/AnonymousInterceptor.cs
@@ -2,8 +2,8 @@ using System;
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public static class CommandBusAnonymousExtensions
 {
     public static void Filter<T>(
@@ -38,4 +38,5 @@ class AnonymousInterceptor<T> : ICommandInterceptor where T : ICommand
         }
         return next(command, context);
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/AnonymousSubscriber.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/AnonymousSubscriber.cs
@@ -2,8 +2,8 @@ using System;
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public static class SubscribableAnonymousExtensions
 {
     public static Subscription Subscribe<T>(this ICommandSubscribable subscribable, Action<T, PublishContext> callback)
@@ -58,4 +58,5 @@ class AnonymousSubscriber<T> : ICommandSubscriber where T : ICommand
             callback(commandCasted, context);
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Attributes.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Attributes.cs
@@ -1,7 +1,7 @@
 using System;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public class PreserveAttribute : Attribute
 {
 }
@@ -26,10 +26,10 @@ public class FilterAttribute : Attribute
         InterceptorType = interceptorType;
     }
 }
-
 #if NET7_0_OR_GREATER
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
 public class FilterAttribute<T> : Attribute where T : ICommandInterceptor
 {
 }
 #endif
+}

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/CommandOrdering.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/CommandOrdering.cs
@@ -2,8 +2,8 @@ using System;
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public enum CommandOrdering
 {
     /// <summary>
@@ -89,4 +89,5 @@ public class FirstInFirstOutOrdering : ICommandInterceptor, IDisposable
     {
         publishLock.Dispose();
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/CommandPool.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/CommandPool.cs
@@ -5,8 +5,8 @@ using System.Runtime.CompilerServices;
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public interface IPoolableCommand : ICommand
 {
     void OnReturnToPool();
@@ -130,4 +130,5 @@ public class CommandPooling : ICommandInterceptor
     {
         CommandPool<T>.Shared.Return(command);
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/FanOutInterceptor.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/FanOutInterceptor.cs
@@ -4,8 +4,8 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public class FanOutInterceptor : ICommandInterceptor
 {
     readonly List<ICommandPublisher> subsequents = new();
@@ -35,4 +35,5 @@ public class FanOutInterceptor : ICommandInterceptor
             executingTasks.Clear();
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/ICommand.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/ICommand.cs
@@ -1,8 +1,8 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public interface ICommand
 {
 }
@@ -43,4 +43,5 @@ public class SequenceCommand : ICommand, IReadOnlyList<ICommand>
     {
         commands.Add(cmd);
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/ICommandInterceptor.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/ICommandInterceptor.cs
@@ -1,8 +1,8 @@
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public delegate UniTask PublishContinuation<in T>(T cmd, PublishContext ctx) where T : ICommand;
 
 public interface ICommandInterceptor
@@ -30,4 +30,5 @@ public abstract class TypedCommandInterceptro<T> : ICommandInterceptor
         T command,
         PublishContext context,
         PublishContinuation<T> next);
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/CappedArrayPool.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/CappedArrayPool.cs
@@ -1,7 +1,7 @@
 using System;
 
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 sealed class CappedArrayPool<T>
 {
     internal const int InitialBucketSize = 4;
@@ -24,6 +24,7 @@ sealed class CappedArrayPool<T>
             {
                 buckets[i][j] = new T[arrayLength];
             }
+
             tails[i] = buckets[i].Length - 1;
         }
     }
@@ -67,4 +68,5 @@ sealed class CappedArrayPool<T>
                 tails[i] -= 1;
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/ExpandBuffer.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/ExpandBuffer.cs
@@ -3,8 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 class ExpandBuffer<T> : IReadOnlyList<T>
 {
     struct Enumerator : IEnumerator<T>
@@ -91,7 +91,7 @@ class ExpandBuffer<T> : IReadOnlyList<T>
             Array.Copy(buffer, index + 1, buffer, index, Count - index);
         }
 #if NETSTANDARD2_1_OR_GREATER
-        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
         {
             buffer[Count] = default!;
@@ -182,4 +182,5 @@ class ExpandBuffer<T> : IReadOnlyList<T>
         }
         SetCapacity(newCapacity);
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/ExpandBuffer.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/ExpandBuffer.cs
@@ -91,7 +91,7 @@ class ExpandBuffer<T> : IReadOnlyList<T>
             Array.Copy(buffer, index + 1, buffer, index, Count - index);
         }
 #if NETSTANDARD2_1_OR_GREATER
-    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
 #endif
         {
             buffer[Count] = default!;

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/FreeList.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/FreeList.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 public class FreeList<T> where T : class
 {
     public int LastIndex => lastIndex;
@@ -129,12 +129,12 @@ public class FreeList<T> where T : class
 
 #if NET6_0_OR_GREATER
 
-    static int FindNullIndex(T?[] target)
-    {
-        var span = MemoryMarshal.CreateReadOnlySpan(
-            ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), target.Length);
-        return span.IndexOf(IntPtr.Zero);
-    }
+static int FindNullIndex(T?[] target)
+{
+    var span = MemoryMarshal.CreateReadOnlySpan(
+        ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), target.Length);
+    return span.IndexOf(IntPtr.Zero);
+}
 
 #else
 
@@ -148,11 +148,11 @@ public class FreeList<T> where T : class
 #if NETSTANDARD2_1
             return span.IndexOf(IntPtr.Zero);
 #else
-            for (int i = 0; i < span.Length; i++)
-            {
-                if (span[i] == IntPtr.Zero) return i;
-            }
-            return -1;
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (span[i] == IntPtr.Zero) return i;
+        }
+        return -1;
 #endif
         }
     }
@@ -161,13 +161,13 @@ public class FreeList<T> where T : class
 
 #if NET8_0_OR_GREATER
 
-    static int FindLastNonNullIndex(T?[] target, int lastIndex)
-    {
-        var span = MemoryMarshal.CreateReadOnlySpan(
-            ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), lastIndex); // without lastIndexed value.
-        var index = span.LastIndexOfAnyExcept(IntPtr.Zero);
-        return index; // return -1 is ok(means empty)
-    }
+static int FindLastNonNullIndex(T?[] target, int lastIndex)
+{
+    var span = MemoryMarshal.CreateReadOnlySpan(
+        ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), lastIndex); // without lastIndexed value.
+    var index = span.LastIndexOfAnyExcept(IntPtr.Zero);
+    return index; // return -1 is ok(means empty)
+}
 
 #else
 
@@ -188,4 +188,5 @@ public class FreeList<T> where T : class
     }
 
 #endif
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/FreeList.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/FreeList.cs
@@ -129,12 +129,12 @@ public class FreeList<T> where T : class
 
 #if NET6_0_OR_GREATER
 
-static int FindNullIndex(T?[] target)
-{
-    var span = MemoryMarshal.CreateReadOnlySpan(
-        ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), target.Length);
-    return span.IndexOf(IntPtr.Zero);
-}
+    static int FindNullIndex(T?[] target)
+    {
+        var span = MemoryMarshal.CreateReadOnlySpan(
+            ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), target.Length);
+        return span.IndexOf(IntPtr.Zero);
+    }
 
 #else
 
@@ -148,11 +148,11 @@ static int FindNullIndex(T?[] target)
 #if NETSTANDARD2_1
             return span.IndexOf(IntPtr.Zero);
 #else
-        for (int i = 0; i < span.Length; i++)
-        {
-            if (span[i] == IntPtr.Zero) return i;
-        }
-        return -1;
+            for (int i = 0; i < span.Length; i++)
+            {
+                if (span[i] == IntPtr.Zero) return i;
+            }
+            return -1;
 #endif
         }
     }
@@ -161,13 +161,13 @@ static int FindNullIndex(T?[] target)
 
 #if NET8_0_OR_GREATER
 
-static int FindLastNonNullIndex(T?[] target, int lastIndex)
-{
-    var span = MemoryMarshal.CreateReadOnlySpan(
-        ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), lastIndex); // without lastIndexed value.
-    var index = span.LastIndexOfAnyExcept(IntPtr.Zero);
-    return index; // return -1 is ok(means empty)
-}
+    static int FindLastNonNullIndex(T?[] target, int lastIndex)
+    {
+        var span = MemoryMarshal.CreateReadOnlySpan(
+            ref UnsafeHelper.As<T?, IntPtr>(ref MemoryMarshal.GetArrayDataReference(target)), lastIndex); // without lastIndexed value.
+        var index = span.LastIndexOfAnyExcept(IntPtr.Zero);
+        return index; // return -1 is ok(means empty)
+    }
 
 #else
 

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/ReusableWhenAllSource.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/ReusableWhenAllSource.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 sealed class ReusableWhenAllSource : IUniTaskSource
 {
     public UniTask Task => new(this, core.Version);
@@ -151,4 +151,5 @@ sealed class ReusableWhenAllSource : IUniTaskSource
             if (lockTaken) spinLock.Exit();
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/Shims.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/Shims.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 #if !NETSTANDARD2_1_OR_GREATER
 public static class Shims
 {
@@ -17,3 +17,4 @@ public static class Shims
     }
 }
 #endif
+}

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/UniTaskAsyncLock.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/UniTaskAsyncLock.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 class UniTaskAsyncLock : IDisposable
 {
     readonly Queue<AutoResetUniTaskCompletionSource> asyncWaitingQueue = new();
@@ -150,4 +150,5 @@ class UniTaskAsyncLock : IDisposable
             throw new ObjectDisposedException(nameof(UniTaskAsyncLock));
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/UnsafeHelper.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/UnsafeHelper.cs
@@ -1,5 +1,5 @@
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 static class UnsafeHelper
 {
     public static ref TTo As<TFrom, TTo>(ref TFrom from)
@@ -7,7 +7,8 @@ static class UnsafeHelper
 #if UNITY_2021_3_OR_NEWER
         return ref global::Unity.Collections.LowLevel.Unsafe.UnsafeUtility.As<TFrom, TTo>(ref from);
 #else
-        return ref System.Runtime.CompilerServices.Unsafe.As<TFrom, TTo>(ref from);
+    return ref System.Runtime.CompilerServices.Unsafe.As<TFrom, TTo>(ref from);
 #endif
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/UnsafeHelper.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Internal/UnsafeHelper.cs
@@ -7,7 +7,7 @@ static class UnsafeHelper
 #if UNITY_2021_3_OR_NEWER
         return ref global::Unity.Collections.LowLevel.Unsafe.UnsafeUtility.As<TFrom, TTo>(ref from);
 #else
-    return ref System.Runtime.CompilerServices.Unsafe.As<TFrom, TTo>(ref from);
+        return ref System.Runtime.CompilerServices.Unsafe.As<TFrom, TTo>(ref from);
 #endif
     }
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/MapRoutesInfo.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/MapRoutesInfo.cs
@@ -3,8 +3,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace VitalRouter.Internal;
-
+namespace VitalRouter.Internal
+{
 public class MapRoutesInfo
 {
     static readonly ConcurrentDictionary<Type, MapRoutesInfo> Cache = new();
@@ -40,4 +40,5 @@ public class InterceptorStackBuilder
         Types.Add(typeof(T));
         return this;
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/PublishContext.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/PublishContext.cs
@@ -4,8 +4,8 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public class PublishContext
 {
     /// <summary>
@@ -141,4 +141,5 @@ public class PublishContext<T> : PublishContext where T : ICommand
         nextInterceptor = default!;
         return false;
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/R3Extensions.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/R3Extensions.cs
@@ -6,8 +6,8 @@ using Cysharp.Threading.Tasks;
 using R3;
 using VitalRouter.Internal;
 
-namespace VitalRouter.R3;
-
+namespace VitalRouter.R3
+{
 public static class R3Extensions
 {
     public static IDisposable SubscribeToPublish<T>(this Observable<T> source, ICommandPublisher publisher)
@@ -294,3 +294,4 @@ sealed class ForEachPublishAndAwaitObserver<T> : Observer<T> where T : ICommand
     }
 }
 #endif
+}

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/ReceiveContext.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/ReceiveContext.cs
@@ -1,8 +1,8 @@
 using System.Collections.Concurrent;
 using Cysharp.Threading.Tasks;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public class ReceiveContext<T> where T : ICommand
 {
     public static async UniTask InvokeAsync(T command, ICommandInterceptor[] interceptorStack, PublishContext context)
@@ -72,4 +72,5 @@ public class ReceiveContext<T> where T : ICommand
         nextInterceptor = default!;
         return false;
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Router.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Router.cs
@@ -6,8 +6,8 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using VitalRouter.Internal;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public interface ICommandPublisher
 {
     UniTask PublishAsync<T>(
@@ -269,4 +269,5 @@ public sealed partial class Router : ICommandPublisher, ICommandSubscribable, ID
             }
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Subscription.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Subscription.cs
@@ -1,7 +1,7 @@
 using System;
 
-namespace VitalRouter;
-
+namespace VitalRouter
+{
 public struct Subscription : IDisposable
 {
     readonly ICommandSubscribable commandBus;
@@ -43,4 +43,5 @@ public struct Subscription : IDisposable
             asyncSubscriber = null;
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/SubscriptionHandle.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/SubscriptionHandle.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace VitalRouter.Unity;
-
+namespace VitalRouter.Unity
+{
 public class SubscriptionHandle : MonoBehaviour
 {
     public List<Subscription> Subscriptions { get; } = new();
@@ -14,4 +14,5 @@ public class SubscriptionHandle : MonoBehaviour
             subscription.Dispose();
         }
     }
+}
 }

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/VContainerExtensions.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/VContainerExtensions.cs
@@ -5,8 +5,8 @@ using VContainer;
 using VContainer.Unity;
 using VitalRouter.Internal;
 
-namespace VitalRouter.VContainer;
-
+namespace VitalRouter.VContainer
+{
 class RoutingDisposable : IDisposable
 {
     readonly IObjectResolver container;
@@ -237,3 +237,4 @@ public static class VContainerExtensions
     }
 }
 #endif
+}

--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/csc.rsp
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/csc.rsp
@@ -1,1 +1,1 @@
--langVersion:10 -nullable
+-nullable

--- a/src/VitalRouter.Unity/Assets/csc.rsp
+++ b/src/VitalRouter.Unity/Assets/csc.rsp
@@ -1,1 +1,1 @@
--langVersion:preview -nullable
+-nullable

--- a/src/VitalRouter.Unity/LangVersion.props
+++ b/src/VitalRouter.Unity/LangVersion.props
@@ -1,6 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR removes the language version flags from the `csc.rsp` and `LanguageVersions.props` files inside the `VitalRouter.Unity` project. The only language feature affected is *file scoped namespaces*, which have been reverted to the usual *block scope namespaces*. The code inside these new scopes has not been indented properly, in order to avoid a lot of meaningless diffs.

The reasoning for these changes is as follows:
In order to use a language version not officially supported by Unity, a special flag needs to be supplied to the compiler via `csc.rsp` files. Unfortunatly IDEs (such as JetBrains Rider) do not utilitze these files and instead use the `*.csproj` files generated by Unity for such information. In order to set the language version in `*.csproj` files however, a special package such as [`Cysharp/CsprojModifier`](https://www.github.com/Cysharp/CsprojModifier) has to be used.

In my opinion requiring users to install and setup another package is hard to justify, just so this package can make use of relatively inconsequential syntax sugar. Even more importantly, `CsprojModifier` cannot apply patches to a specific assembly without modifying the main project assembly as well. We would have to use an unsupported language version throughout our entire project, which I definitely do not want to do.