### PR TITLE
 Fix Convert file scope namespaces to block scope

### DIFF
--- a/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/VContainerExtensions.cs
+++ b/src/VitalRouter.Unity/Assets/VitalRouter/Runtime/Unity/VContainerExtensions.cs
@@ -236,5 +236,5 @@ public static class VContainerExtensions
 
     }
 }
-#endif
 }
+#endif


### PR DESCRIPTION
 Fix Convert file scope namespaces to block scope when VContainer not installed