### PR TITLE
Add support for MRubyValueSerializerOptions to MRubySharedVariableTable

### DIFF
--- a/src/VitalRouter.MRuby/MRubySharedVariableTable.cs
+++ b/src/VitalRouter.MRuby/MRubySharedVariableTable.cs
@@ -8,10 +8,12 @@ namespace VitalRouter.MRuby
     {
         readonly Dictionary<Symbol, MRubyValue> serializedValues = new();
         readonly MRubyState state;
+        readonly MRubyValueSerializerOptions options;
 
-        public MRubySharedVariableTable(MRubyState state)
+        public MRubySharedVariableTable(MRubyState state, MRubyValueSerializerOptions options)
         {
             this.state = state;
+            this.options = options;
         }
 
         public Dictionary<Symbol, MRubyValue>.KeyCollection Keys => serializedValues.Keys;
@@ -55,7 +57,7 @@ namespace VitalRouter.MRuby
 
         public void Set<T>(Symbol key, T value)
         {
-            var mrubyValue = MRubyValueSerializer.Serialize(value, state);
+            var mrubyValue = MRubyValueSerializer.Serialize(value, state, options);
             serializedValues[key] = mrubyValue;
         }
 

--- a/src/VitalRouter.MRuby/MRubyStateExtensions.cs
+++ b/src/VitalRouter.MRuby/MRubyStateExtensions.cs
@@ -117,7 +117,13 @@ public static class MRubyStateExtensions
             {
                 sharedStateClass.DefineMethod(mrb.Intern("initialize"u8), (s, self) =>
                 {
-                    var table = new MRubySharedVariableTable(mrb);
+                    var options = MRubyValueSerializerOptions.Default;
+                    if (s.TryGetConst(s.Intern("VITALROUTER_SERIALIZER_OPTIONS"), s.ObjectClass, out var value))
+                    {
+                        options = value.As<RData>().Data as MRubyValueSerializerOptions;
+                    }
+
+                    var table = new MRubySharedVariableTable(mrb, options);
                     var data = new RData(table);
                     s.SetInstanceVariable(self.As<RObject>(), s.Intern("@table"u8), data);
                     return self;


### PR DESCRIPTION
This PR adds support for MRubyValueSerializerOptions in MRubySharedVariableTable.

With this change, it is no longer necessary to manually serialize values before setting them. You can now pass values directly, and they will be handled automatically.

**Before:**

```csharp
mrb.AddSerializerOptions(options);
var shared = mrb.GetSharedVariables();

shared.Set("characterMasterId", MRubyValueSerializer.Serialize(characterMaster.Id, mrb, options)); 
```

**After:**

```csharp
shared.Set("characterMasterId", characterMaster.Id); // can be passed directly
```

This simplifies the API and improves usability by reducing boilerplate serialization code.