### PR TITLE
Rename Enqueue to Publish, keep Enqueue as alias

### DIFF
--- a/src/VitalRouter/CommandPublisherExtensions.cs
+++ b/src/VitalRouter/CommandPublisherExtensions.cs
@@ -42,12 +42,35 @@ public static class CommandPublisherExtensions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Enqueue<T>(this ICommandPublisher publisher, T command, CancellationToken cancellation = default)
+    public static void Publish<T>(this ICommandPublisher publisher, T command, CancellationToken cancellation = default)
         where T : ICommand
     {
         publisher.PublishAsync(command, cancellation);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Publish(
+        this ICommandPublisher publisher,
+        Type commandType,
+        object command,
+        CancellationToken cancellation = default)
+    {
+        publisher.PublishAsync(commandType, command, cancellation);
+    }
+
+    /// <summary>
+    /// Alias for <see cref="Publish{T}(ICommandPublisher, T, CancellationToken)"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Enqueue<T>(this ICommandPublisher publisher, T command, CancellationToken cancellation = default)
+        where T : ICommand
+    {
+        publisher.Publish(command, cancellation);
+    }
+
+    /// <summary>
+    /// Alias for <see cref="Publish(ICommandPublisher, Type, object, CancellationToken)"/>.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void Enqueue(
         this ICommandPublisher publisher,
@@ -55,7 +78,7 @@ public static class CommandPublisherExtensions
         object command,
         CancellationToken cancellation = default)
     {
-        publisher.PublishAsync(commandType, command, cancellation);
+        publisher.Publish(commandType, command, cancellation);
     }
 }
 }


### PR DESCRIPTION
## Summary
- Rename the fire-and-forget (sync) versions of `PublishAsync` from `Enqueue` to `Publish` in `CommandPublisherExtensions`
- Keep `Enqueue<T>` and `Enqueue(Type, ...)` as aliases that delegate to `Publish`, so existing code keeps compiling

## Motivation
The name `Enqueue` for the sync version of `PublishAsync` was confusing. `Publish` matches the async counterpart naming.

## Notes
- No `[Obsolete]` on `Enqueue` for now; it remains a supported alias
- All 41 tests in VitalRouter.Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)